### PR TITLE
Improve voicestate handling logic

### DIFF
--- a/cogs/voicestate.py
+++ b/cogs/voicestate.py
@@ -1,4 +1,5 @@
 import copy
+import time
 from typing import Collection, Tuple
 
 import discord
@@ -40,6 +41,9 @@ class VoiceState(commands.Cog):
 
     @tasks.loop(seconds=5)
     async def process_queues(self):
+        start_time = time.perf_counter()
+        processed_members = 0
+
         try:
             # Create a copy of the member_queues and clear the original
             member_queues = self.member_queues.copy()
@@ -91,8 +95,17 @@ class VoiceState(commands.Cog):
                             member, set(to_add), set(to_remove), new_nick
                         )
                     )
+
+                    processed_members += 1
+
         except Exception as e:
             self.client.log(LogLevel.ERROR, f"Error processing member queues: {e}")
+
+        end_time = time.perf_counter()
+        self.client.log(
+            LogLevel.DEBUG,
+            f"Processed {processed_members} member queues in {end_time - start_time:.2f} seconds",
+        )
 
     @process_queues.before_loop
     async def before_process_queues(self):


### PR DESCRIPTION
Split requests more intelligently across multiple endpoints when adding/removing roles or updating username.

This will help avoid rate limiting issues, not necessarily preventing them though (this is impossible).

Instead of just using the `Modify Guild Member` endpoint for username and role changes, the bot will now also use the `Add Guild Member Role` and `Remove Guild Member Role` endpoints where applicable.

The basic logic now checks if there are multiple operations to do (i.e. changing username AND adding/removing roles or just adding/removing multiple roles) and if so call the `Modify Guild Member` endpoint, if instead only one role needs to be added or removed, it will call the `Add Guild Member Role` or `Remove Guild Member Role`. If a single role needs to be added or a single role needs to be removed, this will still result in the bot using the `Modify Guild Member` endpoint to reduce number of API requests rather than 2 separate calls.

These changes will be monitored to ensure that they work as intended, but I don't foresee this introducing any new issues.